### PR TITLE
Fix wrong attribute in request object

### DIFF
--- a/rarbg.py
+++ b/rarbg.py
@@ -100,7 +100,7 @@ async def api(params):
 
 
 async def rarbg_rss(request):
-    params = dict(request.GET)
+    params = dict(request.query)
     if 'string' in request.match_info:
         params.update(mode='search', search_string=request.match_info['string'])
     if 'imdb' in request.match_info:


### PR DESCRIPTION
I was seeing this error:
```
AttributeError: 'Request' object has no attribute 'GET'
```
The correct attribute is `query`.