### PR TITLE
Update rarbg.py

### DIFF
--- a/rarbg.py
+++ b/rarbg.py
@@ -32,6 +32,7 @@ TEMPLATE = Template('''\
             <description/>
             <guid>{{entry.hash}}</guid>
             <pubDate>{{entry.pubdate}}</pubDate>
+            <link>{{entry.download}}</link>
             <enclosure
                 url="{{entry.download | e}}"
                 length="{{entry.size}}"


### PR DESCRIPTION
For some reason the RSS parser I use can't deal with `<enclosure>`. I'll submit a PR there too, but this is my monkey patch for this tool. I totally understand if this PR were to get rejected, but I thought I might not be alone in needing `<link>` instead of `<enclosure>`.